### PR TITLE
Revert ZeroDivisionError handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,9 +6,5 @@ sentry_sdk.init(
 )
 
 print("Starting application...")
-try:
-    division_by_zero = 1 / 0
-except ZeroDivisionError:
-    print("Caught division by zero error - handling gracefully")
-    sentry_sdk.capture_message("Division by zero attempted but handled", level="warning")
+division_by_zero = 1 / 0
 print("Application running successfully")


### PR DESCRIPTION
This PR reverts the commit cad73b4 that added graceful handling for division by zero errors.

**Changes:**
- Removes the try/except block that was catching ZeroDivisionError
- Returns the application to its original state where it crashes on division by zero
- This effectively revokes the commit that was pushed to main

**Reason for revert:**
The commit was pushed directly to main and needs to be revoked as requested.